### PR TITLE
fix bug when test lineprof readme example

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -54,6 +54,7 @@ parse_prof <- function(path) {
   prof <- raw[!is_label, ]
   prof$V1 <- NULL
   prof$V2 <- as.numeric(prof$V2)
+  prof$V3 <- as.numeric(prof$V3)
   names(prof) <- c("small_v", "big_v", "nodes", "dups", "source")
 
   # Add time info, and compute total memory (rounded to meg's)

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -1,0 +1,2 @@
+library("testthat")
+test_check("lineprof")


### PR DESCRIPTION
```
 source(find_ex("read-delim.r"))
 wine <- find_ex("wine.csv")
 x <- lineprof(read_delim(wine, sep = ","), torture = TRUE)

Error in prof$small_v + prof$big_v : 
  non-numeric argument to binary operator
```
