### PR TITLE
Fix a bug in contains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ Imports:
     shiny
 LinkingTo: Rcpp (>= 0.11.0)
 Roxygen: list(wrap = FALSE)
+Suggests:
+    testthat

--- a/src/contains.cpp
+++ b/src/contains.cpp
@@ -9,14 +9,11 @@ using namespace Rcpp;
 // [[Rcpp::export]]
 int contains(CharacterVector haystack, CharacterVector needle) {
   for (int i = 0; i < haystack.length() - needle.length() + 1; ++i) {
-    // Search until find first matching element
-    if (haystack[i] != needle[0]) continue;
-    
-    // Check remaining elements match
-    for (int j = 1; j < needle.length(); ++j) {
-      if (haystack[i + j] != needle[j]) return 0;
-    }
-    return i + 1;
+    // Keep track of how many characters we successfully matched
+    int j;
+    for (j = 0; j < needle.length() && haystack[i + j] == needle[j]; ++j);
+    // Matched every element
+    if (j == needle.length()) return i + 1;
   }
   
   return 0;

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(lineprof)
+
+test_check("lineprof")

--- a/tests/testthat/test-contains.R
+++ b/tests/testthat/test-contains.R
@@ -1,0 +1,25 @@
+context("contains.cpp")
+
+test_that("returns starting index if found", {
+  #one string
+  expect_equal(contains(letters, "a"), 1)
+  #two strings
+  expect_equal(contains(letters, c("b", "c")), 2)
+  #multi-strings with failed partial match
+  expect_equal(contains(c("a", letters), letters), 2)
+})
+
+test_that("returns 0 if not found", {
+  #doesn't exist
+  expect_equal(contains(letters, "1"), 0)
+  #failed partial match
+  expect_equal(contains(letters, c("b", "a")), 0)
+  #haystack is substring of needle should also fail
+  expect_equal(contains(letters, c(letters, "a")), 0)
+})
+
+test_that("works for empty inputs", {
+  expect_equal(contains(character(), "foo"), 0)
+  expect_equal(contains("foo", character()), 1)
+  expect_equal(contains(character(), character()), 1)
+})


### PR DESCRIPTION
There is a bug in `contains` when the `haystack` contains duplicates that is part of `needle`.

For example
```r
lineprof:::contains(c("a","a","b"), c("a","b"))
```
returns 0 where it should return 2

This seems to cause #16. I also encountered similar issues when profiling codes that use  `dplyr` where consecutive nested `eval` is quite common with `magrittr`.

I have tested with the following
```r
lineprof:::contains(c("a","a","b"), c("a"))
# 1
lineprof:::contains(c("a","a","b"), c("a", "b"))
# 2
lineprof:::contains(c("a","a","b"), c("a", "c"))
# 0
lineprof:::contains(c("a","a","b"), c("c"))
# 0
lineprof:::contains(c("a","a","b"), character())
# 1
```

Let me know if there is any concerns/suggestions on the implementation logic or code style.