### PR TITLE
Enable writing raw Rprof output to user-defined file

### DIFF
--- a/R/lineprof.r
+++ b/R/lineprof.r
@@ -69,11 +69,15 @@
 #' }
 #' @useDynLib lineprof
 #' @importFrom Rcpp sourceCpp
-lineprof <- function(code, interval = 0.001, torture = FALSE) {
-  path <- line_profile(code, interval, torture)
-  on.exit(unlink(path))
+lineprof <- function(code, interval = 0.001, torture = FALSE, prof_path = "") {
 
-  parse_prof(path)
+  if (prof_path=="") {
+	prof_path <- tempfile(fileext = ".prof")
+    on.exit(unlink(prof_path))
+  }
+
+  line_profile(code, interval, torture, prof_path)
+  parse_prof(prof_path)
 }
 
 is.lineprof <- function(x) inherits(x, "lineprof")

--- a/R/lineprof.r
+++ b/R/lineprof.r
@@ -54,6 +54,9 @@
 #'   if you want to see exactly when memory is released. It also makes R run
 #'   extremely slowly (10-100x slower than usual) so it can also be useful to
 #'   simulate a smaller \code{interval}.
+#' @param prof_path path to file where the raw profiling output should be saved.
+#'   The default value, \code{""}, writes the raw data to a temporary file that 
+#'   that is deleted when the program exits.
 #' @export
 #' @examples
 #' source(find_ex("read-delim.r"))

--- a/R/lineprof.r
+++ b/R/lineprof.r
@@ -55,7 +55,7 @@
 #'   extremely slowly (10-100x slower than usual) so it can also be useful to
 #'   simulate a smaller \code{interval}.
 #' @param prof_path path to file where the raw profiling output should be saved.
-#'   The default value, \code{""}, writes the raw data to a temporary file that 
+#'   The default value, \code{NULL}, writes the raw data to a temporary file that 
 #'   that is deleted when the program exits.
 #' @export
 #' @examples
@@ -72,14 +72,14 @@
 #' }
 #' @useDynLib lineprof
 #' @importFrom Rcpp sourceCpp
-lineprof <- function(code, interval = 0.001, torture = FALSE, prof_path = "") {
+lineprof <- function(code, interval = 0.001, torture = FALSE, prof_path = NULL) {
 
-  if (prof_path=="") {
-	prof_path <- tempfile(fileext = ".prof")
+  if (is.null(prof_path)) {
+    prof_path <- tempfile(fileext = ".prof")
     on.exit(unlink(prof_path))
   }
 
-  line_profile(code, interval, torture, prof_path)
+  line_profile(code, prof_path, interval, torture)
   parse_prof(prof_path)
 }
 

--- a/R/profile.R
+++ b/R/profile.R
@@ -6,8 +6,7 @@
 #' @keywords internal
 #' @inheritParams lineprof
 #' @export
-line_profile <- function(code, interval = 0.01, torture = FALSE) {
-  prof_path <- tempfile(fileext = ".prof")
+line_profile <- function(code, interval = 1.01, torture = FALSE, prof_path) {
 
   if (torture) {
     gctorture(TRUE)
@@ -20,7 +19,6 @@ line_profile <- function(code, interval = 0.01, torture = FALSE) {
   on.exit(Rprof(NULL), add = TRUE)
   force(code)
 
-  prof_path
 }
 
 #' @rdname line_profile

--- a/R/profile.R
+++ b/R/profile.R
@@ -6,7 +6,7 @@
 #' @keywords internal
 #' @inheritParams lineprof
 #' @export
-line_profile <- function(code, interval = 0.001, torture = FALSE, prof_path) {
+line_profile <- function(code, prof_path, interval = 0.001, torture = FALSE) {
 
   if (torture) {
     gctorture(TRUE)

--- a/R/profile.R
+++ b/R/profile.R
@@ -6,7 +6,7 @@
 #' @keywords internal
 #' @inheritParams lineprof
 #' @export
-line_profile <- function(code, interval = 1.01, torture = FALSE, prof_path) {
+line_profile <- function(code, interval = 0.001, torture = FALSE, prof_path) {
 
   if (torture) {
     gctorture(TRUE)

--- a/man/line_profile.Rd
+++ b/man/line_profile.Rd
@@ -5,7 +5,7 @@
 \alias{parse_prof}
 \title{Profile and parse output}
 \usage{
-line_profile(code, interval = 0.01, torture = FALSE)
+line_profile(code, interval = 0.001, torture = FALSE, prof_path)
 
 parse_prof(path)
 }
@@ -22,6 +22,10 @@ set it to something larger.}
 if you want to see exactly when memory is released. It also makes R run
 extremely slowly (10-100x slower than usual) so it can also be useful to
 simulate a smaller \code{interval}.}
+
+\item{prof_path}{path to file where the raw profiling output should be saved.
+The default value, \code{""}, writes the raw data to a temporary file that
+that is deleted when the program exits.}
 
 \item{path}{path to line profiling data}
 }

--- a/man/line_profile.Rd
+++ b/man/line_profile.Rd
@@ -5,12 +5,16 @@
 \alias{parse_prof}
 \title{Profile and parse output}
 \usage{
-line_profile(code, interval = 0.001, torture = FALSE, prof_path)
+line_profile(code, prof_path, interval = 0.001, torture = FALSE)
 
 parse_prof(path)
 }
 \arguments{
 \item{code}{code to profile.}
+
+\item{prof_path}{path to file where the raw profiling output should be saved.
+The default value, \code{NULL}, writes the raw data to a temporary file that
+that is deleted when the program exits.}
 
 \item{interval}{interval, in seconds, between profile snapshots. R's timer
 has a resolution of at best 1 ms, so there's no reason to make this value
@@ -22,10 +26,6 @@ set it to something larger.}
 if you want to see exactly when memory is released. It also makes R run
 extremely slowly (10-100x slower than usual) so it can also be useful to
 simulate a smaller \code{interval}.}
-
-\item{prof_path}{path to file where the raw profiling output should be saved.
-The default value, \code{""}, writes the raw data to a temporary file that
-that is deleted when the program exits.}
 
 \item{path}{path to line profiling data}
 }

--- a/man/lineprof.Rd
+++ b/man/lineprof.Rd
@@ -4,7 +4,7 @@
 \alias{lineprof}
 \title{Line profiling.}
 \usage{
-lineprof(code, interval = 0.001, torture = FALSE, prof_path = "")
+lineprof(code, interval = 0.001, torture = FALSE, prof_path = NULL)
 }
 \arguments{
 \item{code}{code to profile.}
@@ -21,7 +21,7 @@ extremely slowly (10-100x slower than usual) so it can also be useful to
 simulate a smaller \code{interval}.}
 
 \item{prof_path}{path to file where the raw profiling output should be saved.
-The default value, \code{""}, writes the raw data to a temporary file that
+The default value, \code{NULL}, writes the raw data to a temporary file that
 that is deleted when the program exits.}
 }
 \description{

--- a/man/lineprof.Rd
+++ b/man/lineprof.Rd
@@ -4,7 +4,7 @@
 \alias{lineprof}
 \title{Line profiling.}
 \usage{
-lineprof(code, interval = 0.001, torture = FALSE)
+lineprof(code, interval = 0.001, torture = FALSE, prof_path = "")
 }
 \arguments{
 \item{code}{code to profile.}
@@ -19,6 +19,10 @@ set it to something larger.}
 if you want to see exactly when memory is released. It also makes R run
 extremely slowly (10-100x slower than usual) so it can also be useful to
 simulate a smaller \code{interval}.}
+
+\item{prof_path}{path to file where the raw profiling output should be saved.
+The default value, \code{""}, writes the raw data to a temporary file that
+that is deleted when the program exits.}
 }
 \description{
 \code{lineprof} uses R built-in time and memory profiler \code{\link{Rprof}}


### PR DESCRIPTION
Added an input argument "prof_path" to the function "lineprof" that can be used to specify the path
where the raw Rprof output should be saved. The default value ("") causes the program to create a
temporary file for Rprof output and delete it upon exit - the same behavior as the original program.

I think this functionality is would be useful in two ways:
1) It allows the user to generate reports from the raw data using other available tools (e.g. summaryRprof)
2) It makes it possible to debug problems in the parsing process without re-running the code.
